### PR TITLE
Move HttpRequest.Builder to AllowCallable call function

### DIFF
--- a/src/main/scala/org/openpolicyagent/kafka/OpaAuthorizer.scala
+++ b/src/main/scala/org/openpolicyagent/kafka/OpaAuthorizer.scala
@@ -302,13 +302,13 @@ object AllowCallable {
   // If a TrusStore is configured by the user,
   // This HttpClient is replaced by OpaAuthorizer.configure()
   var client = HttpClient.newBuilder.connectTimeout(ofSeconds(5)).build
-  val requestBuilder = HttpRequest.newBuilder.timeout(ofSeconds(5)).header("Content-Type", "application/json")
 }
 class AllowCallable(request: Request, opaUrl: URI, allowOnError: Boolean, metrics: Option[Metrics]) extends Callable[Boolean] with LazyLogging {
   override def call(): Boolean = {
     logger.debug(s"Cache miss, querying OPA for decision")
     val reqJson = AllowCallable.objectMapper.writeValueAsString(request)
-    val req = AllowCallable.requestBuilder.uri(opaUrl).POST(BodyPublishers.ofString(reqJson)).build
+    val requestBuilder = HttpRequest.newBuilder.timeout(ofSeconds(5)).header("Content-Type", "application/json")
+    val req = requestBuilder.uri(opaUrl).POST(BodyPublishers.ofString(reqJson)).build
     logger.debug(s"Querying OPA with object: $reqJson")
     if(metrics.isDefined){
       metrics.get.sensor(MetricsLabel.REQUEST_TO_OPA_COUNT).record()


### PR DESCRIPTION
PR for https://github.com/StyraInc/opa-kafka-plugin/issues/46

According to Java doc, HttpRequest.Builder is not thread-safe. So we should construct it in the `AllowCallable call()` function instead of a static object in `object AllowCallable`