### PR TITLE
Update policies and examples to work with OPA 1.0 and newer

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         run: ./gradlew check shadowJar
       - name: Jacoco test report
         run: ./gradlew jacocoTestReport
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v4
         with:
           name: opa-authorizer
           path: build/libs

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ the accessed resource and the performed operation. _patternType_ is always _LITE
 
 Creation of a topic checks for CLUSTER + CREATE. If this is denied, it will check for TOPIC with its name + CREATE.
 
-When doing idepotent write to a topic, and the first request for operation=IDEMPOTENT_WRITE on the resourceType=CLUSTER is denied,
+When doing idempotent write to a topic, and the first request for operation=IDEMPOTENT_WRITE on the resourceType=CLUSTER is denied,
 the method _authorizeByResourceType_ to check, if the user has the right to write to any topic.
 If yes, the idempotent write is granted by Kafka's ACL-implementation. To allow for a similar check,
 it is mapped to OPA with _patternType=PREFIXED_, _resourceType=TOPIC_, and _name=""_.

--- a/example/README.md
+++ b/example/README.md
@@ -29,7 +29,7 @@ and assume the Kafka root directory as the current working directory.
 Using `alice-mgmt` or `alice-producer`:
 
 ```shell
-bin/kafka-console-producer.sh --broker-list localhost:9093 --topic alice-topic1 --producer.config path/to/cert/client/alice-mgmt.properties
+bin/kafka-console-producer.sh --bootstrap-server localhost:9093 --topic alice-topic1 --producer.config path/to/cert/client/alice-mgmt.properties
 > My first message
 > My second message
 ...
@@ -40,13 +40,11 @@ Ctrl+c
 
 ```shell
 
-bin/kafka-console-producer.sh --broker-list localhost:9093 --topic alice-topic1 --producer.config path/to/cert/client/alice-consumer.properties
+bin/kafka-console-producer.sh --bootstrap-server localhost:9093 --topic alice-topic1 --producer.config path/to/cert/client/alice-consumer.properties
 > My first message
 >[2021-12-01 09:43:45,437] ERROR Error when sending message to topic alice-topic1 with key: null, value: 8 bytes with error: (org.apache.kafka.clients.producer.internals.ErrorLoggingCallback)
 org.apache.kafka.common.errors.TopicAuthorizationException: Not authorized to access topics: [alice-topic1
 ```
-
-
 
 ### Consuming from a topic
 

--- a/example/docker-compose.yaml
+++ b/example/docker-compose.yaml
@@ -6,12 +6,13 @@ services:
     ports:
       - "80:80"
   opa:
-    image: openpolicyagent/opa:0.35.0-rootless
+    image: openpolicyagent/opa:1.2.0
     ports:
       - "8181:8181"
     command:
       - "run"
       - "--server"
+      - "--addr=0.0.0.0:8181"
       - "--set=decision_logs.console=true"
       - "--set=services.authz.url=http://nginx"
       - "--set=bundles.authz.service=authz"

--- a/src/main/rego/policy.rego
+++ b/src/main/rego/policy.rego
@@ -1,122 +1,128 @@
 package kafka.authz
 
-import future.keywords.in
-
 # ----------------------------------------------------
 #  Policies
 # ----------------------------------------------------
 
 default allow = false
 
-allow {
+allow if {
 	inter_broker_communication
 }
 
-allow {
+allow if {
 	consume(input.action)
 	on_own_topic(input.action)
 	as_consumer
 }
 
-allow {
+allow if {
 	produce(input.action)
 	on_own_topic(input.action)
 	as_producer
 }
 
-allow {
+allow if {
 	create(input.action)
 	on_own_topic(input.action)
 }
 
-allow {
+allow if {
 	any_operation(input.action)
 	on_own_topic(input.action)
 	as_mgmt_user
 }
 
-allow {
+allow if {
 	input.action.operation == "READ"
 	input.action.resourcePattern.resourceType == "GROUP"
 }
 
-allow {
+allow if {
 	describe(input.action)
+}
+
+allow if {
+	idempotent_produce(input.action)
 }
 
 # ----------------------------------------------------
 #  Functions
 # ----------------------------------------------------
 
-inter_broker_communication {
+inter_broker_communication if {
 	input.requestContext.principal.name == "ANONYMOUS"
 }
 
-inter_broker_communication {
+inter_broker_communication if {
 	input.requestContext.securityProtocol == "SSL"
 	input.requestContext.principal.principalType == "User"
 	username == "localhost"
 }
 
-consume(action) {
+consume(action) if {
 	action.operation == "READ"
 }
 
-produce(action) {
+produce(action) if {
 	action.operation == "WRITE"
 }
 
-create(action) {
+idempotent_produce(action) if {
+	action.operation == "IDEMPOTENT_WRITE"
+}
+
+create(action) if {
 	action.operation == "CREATE"
 }
 
-describe(action) {
+describe(action) if {
 	action.operation == "DESCRIBE"
 }
 
-any_operation(action) {
+any_operation(action) if {
 	action.operation in ["READ", "WRITE", "CREATE", "ALTER", "DESCRIBE", "DELETE"]
 }
 
-as_consumer {
+as_consumer if {
 	regex.match(".*-consumer", username)
 }
 
-as_producer {
+as_producer if {
 	regex.match(".*-producer", username)
 }
 
-as_mgmt_user {
+as_mgmt_user if {
 	regex.match(".*-mgmt", username)
 }
 
-on_own_topic(action) {
+on_own_topic(action) if {
 	owner := trim(username, "-consumer")
 	regex.match(owner, action.resourcePattern.name)
 }
 
-on_own_topic(action) {
+on_own_topic(action) if {
 	owner := trim(username, "-producer")
 	regex.match(owner, action.resourcePattern.name)
 }
 
-on_own_topic(action) {
+on_own_topic(action) if {
 	owner := trim(username, "-mgmt")
 	regex.match(owner, action.resourcePattern.name)
 }
 
-username = cn_parts[0] {
+username := cn_parts[0] if {
 	name := input.requestContext.principal.name
 	startswith(name, "CN=")
 	parsed := parse_user(name)
 	cn_parts := split(parsed.CN, ".")
 }
 # If client certificates aren't used for authentication
-else = input.requestContext.principal.name {
+else := input.requestContext.principal.name if {
 	true
 }
 
-parse_user(user) = {key: value |
+parse_user(user) := {key: value |
 	parts := split(user, ",")
 	[key, value] := split(parts[_], "=")
 }

--- a/src/test/rego/policy_test.rego
+++ b/src/test/rego/policy_test.rego
@@ -5,12 +5,12 @@ package kafka.authz
 # --------------------------------------------------
 
 # Brokers
-test_inter_broker_communication {
+test_inter_broker_communication if {
 	allow with input.requestContext.principal.name as "ANONYMOUS"
 }
 
 # Consumers
-test_consume_own_topic_as_consumer {
+test_consume_own_topic_as_consumer if {
 	allow with input.requestContext.principal.name as "alice-consumer"
 		 with input.action as {
 			"operation": "READ",
@@ -21,7 +21,7 @@ test_consume_own_topic_as_consumer {
 		}
 }
 
-test_create_own_topic_as_consumer {
+test_create_own_topic_as_consumer if {
 	allow with input.requestContext.principal.name as "alice-consumer"
 		 with input.action as {
 			"operation": "CREATE",
@@ -33,7 +33,7 @@ test_create_own_topic_as_consumer {
 }
 
 # Producers
-test_produce_own_topic_as_producer {
+test_produce_own_topic_as_producer if {
 	allow with input.requestContext.principal.name as "CN=alice-producer, OU=Developers"
 		 with input.action as {
 			"operation": "WRITE",
@@ -44,7 +44,7 @@ test_produce_own_topic_as_producer {
 		}
 }
 
-test_create_own_topic_as_producer {
+test_create_own_topic_as_producer if {
 	allow with input.requestContext.principal.name as "alice-producer"
 		 with input.action as {
 			"operation": "CREATE",
@@ -56,7 +56,7 @@ test_create_own_topic_as_producer {
 }
 
 # Global access
-test_anyone_describe_some_topic {
+test_anyone_describe_some_topic if {
 	allow with input.requestContext.principal.name as "alice-producer"
 		 with input.action as {
 			"operation": "DESCRIBE",
@@ -67,7 +67,7 @@ test_anyone_describe_some_topic {
 		}
 }
 
-test_anyone_describe_own_topic {
+test_anyone_describe_own_topic if {
 	allow with input.requestContext.principal.name as "alice-producer"
 		 with input.action as {
 			"operation": "DESCRIBE",
@@ -79,7 +79,7 @@ test_anyone_describe_own_topic {
 }
 
 # MGMT User tests
-test_mgmt_user_own_topic_read {
+test_mgmt_user_own_topic_read if {
 	allow with input.requestContext.principal.name as "CN=alice-mgmt, O=AcmeCorp"
 		 with input.action as {
 			"operation": "READ",
@@ -90,7 +90,7 @@ test_mgmt_user_own_topic_read {
 		}
 }
 
-test_mgmt_user_own_topic_write {
+test_mgmt_user_own_topic_write if {
 	allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "WRITE",
@@ -101,7 +101,7 @@ test_mgmt_user_own_topic_write {
 		}
 }
 
-test_mgmt_user_own_topic_create {
+test_mgmt_user_own_topic_create if {
 	allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "CREATE",
@@ -112,7 +112,7 @@ test_mgmt_user_own_topic_create {
 		}
 }
 
-test_mgmt_user_own_topic_delete {
+test_mgmt_user_own_topic_delete if {
 	allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "DELETE",
@@ -123,7 +123,7 @@ test_mgmt_user_own_topic_delete {
 		}
 }
 
-test_mgmt_user_own_topic_describe {
+test_mgmt_user_own_topic_describe if {
 	allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "DESCRIBE",
@@ -134,7 +134,7 @@ test_mgmt_user_own_topic_describe {
 		}
 }
 
-test_mgmt_user_own_topic_alter {
+test_mgmt_user_own_topic_alter if {
 	allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "ALTER",
@@ -145,11 +145,24 @@ test_mgmt_user_own_topic_alter {
 		}
 }
 
+# Anyone can do idemportent write
+test_anyone_describe_some_topic if {
+	allow with input.requestContext.principal.name as "alice-producer"
+		 with input.action as {
+			"operation": "IDEMPOTENT_WRITE",
+			"resourcePattern": {
+			    "name": "kafka-cluster",
+			    "patternType": "LITERAL",
+			    "resourceType": "CLUSTER",
+			},
+		}
+}
+
 # --------------------------------------------------
 #   Negative test
 # --------------------------------------------------
 
-test_consume_own_topic_as_producer {
+test_consume_own_topic_as_producer if {
 	not allow with input.requestContext.principal.name as "alice-producer"
 		 with input.action as {
 			"operation": "READ",
@@ -160,7 +173,7 @@ test_consume_own_topic_as_producer {
 		}
 }
 
-test_consume_someone_elses_topic_as_producer {
+test_consume_someone_elses_topic_as_producer if {
 	not allow with input.requestContext.principal.name as "alice-producer"
 		 with input.action as {
 			"operation": "READ",
@@ -171,7 +184,7 @@ test_consume_someone_elses_topic_as_producer {
 		}
 }
 
-test_consume_someone_elses_topic_as_consumer {
+test_consume_someone_elses_topic_as_consumer if {
 	not allow with input.requestContext.principal.name as "alice-consumer"
 		 with input.action as {
 			"operation": "READ",
@@ -182,7 +195,7 @@ test_consume_someone_elses_topic_as_consumer {
 		}
 }
 
-test_produce_own_topic_as_consumer {
+test_produce_own_topic_as_consumer if {
 	not allow with input.requestContext.principal.name as "alice-consumer"
 		 with input.action as {
 			"operation": "WRITE",
@@ -193,7 +206,7 @@ test_produce_own_topic_as_consumer {
 		}
 }
 
-test_produce_someone_elses_topic_as_consumer {
+test_produce_someone_elses_topic_as_consumer if {
 	not allow with input.requestContext.principal.name as "alice-consumer"
 		 with input.action as {
 			"operation": "WRITE",
@@ -204,7 +217,7 @@ test_produce_someone_elses_topic_as_consumer {
 		}
 }
 
-test_produce_someone_elses_topic_as_producer {
+test_produce_someone_elses_topic_as_producer if {
 	not allow with input.requestContext.principal.name as "alice-producer"
 		 with input.action as {
 			"operation": "WRITE",
@@ -215,7 +228,7 @@ test_produce_someone_elses_topic_as_producer {
 		}
 }
 
-test_create_someone_elses_topic_as_producer {
+test_create_someone_elses_topic_as_producer if {
 	not allow with input.requestContext.principal.name as "alice-producer"
 		 with input.action as {
 			"operation": "CREATE",
@@ -226,7 +239,7 @@ test_create_someone_elses_topic_as_producer {
 		}
 }
 
-test_create_someone_elses_topic_as_consumer {
+test_create_someone_elses_topic_as_consumer if {
 	not allow with input.requestContext.principal.name as "alice-producer"
 		 with input.action as {
 			"operation": "CREATE",
@@ -238,7 +251,7 @@ test_create_someone_elses_topic_as_consumer {
 }
 
 # MGMT User tests
-test_mgmt_user_other_topic_read {
+test_mgmt_user_other_topic_read if {
 	not allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "READ",
@@ -249,7 +262,7 @@ test_mgmt_user_other_topic_read {
 		}
 }
 
-test_mgmt_user_other_topic_write {
+test_mgmt_user_other_topic_write if {
 	not allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "WRITE",
@@ -260,7 +273,7 @@ test_mgmt_user_other_topic_write {
 		}
 }
 
-test_mgmt_user_other_topic_create {
+test_mgmt_user_other_topic_create if {
 	not allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "CREATE",
@@ -271,7 +284,7 @@ test_mgmt_user_other_topic_create {
 		}
 }
 
-test_mgmt_user_other_topic_delete {
+test_mgmt_user_other_topic_delete if {
 	not allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "DELETE",
@@ -282,7 +295,7 @@ test_mgmt_user_other_topic_delete {
 		}
 }
 
-test_mgmt_user_other_topic_alter {
+test_mgmt_user_other_topic_alter if {
 	not allow with input.requestContext.principal.name as "alice-mgmt"
 		 with input.action as {
 			"operation": "ALTER",


### PR DESCRIPTION
This PR updates the test policies and the example to work with OPA 1.0 and newer (the docker Compose file was updated to use 1.2.0 as the latest version as of now). It adds support for idempotent write in order to make the policy work with newer Kafka clients which use it by default.

It also updates the GitHub Upload Action as the original version is not supported anymore.